### PR TITLE
Fix header trailing whitespace issue with xml export

### DIFF
--- a/lib/msexcel-builder.js
+++ b/lib/msexcel-builder.js
@@ -138,7 +138,7 @@
       });
       wb.att('xmlns', 'http://schemas.openxmlformats.org/spreadsheetml/2006/main');
       wb.att('xmlns:r', 'http://schemas.openxmlformats.org/officeDocument/2006/relationships');
-      wb.ele('fileVersion ', {
+      wb.ele('fileVersion', {
         appName: 'xl',
         lastEdited: '4',
         lowestEdited: '4',
@@ -148,7 +148,7 @@
         filterPrivacy: '1',
         defaultThemeVersion: '124226'
       });
-      wb.ele('bookViews').ele('workbookView ', {
+      wb.ele('bookViews').ele('workbookView', {
         xWindow: '0',
         yWindow: '90',
         windowWidth: '19200',

--- a/src/msexcel-builder.coffee
+++ b/src/msexcel-builder.coffee
@@ -61,9 +61,9 @@ class XlWorkbook
     wb = xml.create('workbook',{version:'1.0',encoding:'UTF-8',standalone:true})
     wb.att('xmlns','http://schemas.openxmlformats.org/spreadsheetml/2006/main')
     wb.att('xmlns:r','http://schemas.openxmlformats.org/officeDocument/2006/relationships')
-    wb.ele('fileVersion ',{appName:'xl',lastEdited:'4',lowestEdited:'4',rupBuild:'4505'})
-    wb.ele('workbookPr',{filterPrivacy:'1',defaultThemeVersion:'124226'}) 
-    wb.ele('bookViews').ele('workbookView ',{xWindow:'0',yWindow:'90',windowWidth:'19200',windowHeight:'11640'})
+    wb.ele('fileVersion',{appName:'xl',lastEdited:'4',lowestEdited:'4',rupBuild:'4505'})
+    wb.ele('workbookPr',{filterPrivacy:'1',defaultThemeVersion:'124226'})
+    wb.ele('bookViews').ele('workbookView',{xWindow:'0',yWindow:'90',windowWidth:'19200',windowHeight:'11640'})
     tmp = wb.ele('sheets')
     for i in [1..@book.sheets.length]
       tmp.ele('sheet',{name:@book.sheets[i-1].name,sheetId:''+i,'r:id':'rId'+i})
@@ -72,7 +72,7 @@ class XlWorkbook
 
 class XlRels
   constructor: (@book)->
-  
+
   toxml: ()->
     rs = xml.create('Relationships',{version:'1.0',encoding:'UTF-8',standalone:true})
     rs.att('xmlns','http://schemas.openxmlformats.org/package/2006/relationships')


### PR DESCRIPTION
### Problem
When running the excel builder, an error would appear within XML Stringify, stating there was an improper header name.

### Source
Upon investigation, the element names in question that caused the issue were `'fileVersion '` and `'workbookView '`.

Looking at the regex in the XML package, these should not have the spaces in it to work as intended. I presume the XML package has updated at some point to not allow for these spaces.

### Solution
Changed these headers to not include the trailing space.